### PR TITLE
Enable XSD validation for Doctrine ORM 3.0 compat

### DIFF
--- a/src/symfony/src/WebauthnBundle.php
+++ b/src/symfony/src/WebauthnBundle.php
@@ -94,7 +94,7 @@ final class WebauthnBundle extends Bundle
         ];
         if (class_exists(DoctrineOrmMappingsPass::class)) {
             $container->addCompilerPass(
-                DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, []),
+                DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, [], false, [], true),
                 PassConfig::TYPE_BEFORE_OPTIMIZATION,
                 0
             );


### PR DESCRIPTION
Implements https://github.com/doctrine/DoctrineBundle/pull/1679 to silence the logged deprecation message

>  User Deprecated: Using XML mapping driver with XSD validation disabled is deprecated and will not be supported in Doctrine ORM 3.0. (XmlDriver.php:60 called by App_KernelDevDebugContainer.php:946, https://github.com/doctrine/orm/pull/6728, package doctrine/orm

![ScreenShot-2023-11-16-23 28 49](https://github.com/PhilETaylor/webauthn-framework/assets/400092/0586190f-8aa8-432e-a2b3-d735540696e5)
